### PR TITLE
Fix player limit clamping

### DIFF
--- a/app/Data/AnnounceProcessor.php
+++ b/app/Data/AnnounceProcessor.php
@@ -597,8 +597,8 @@ final class AnnounceProcessor
         if ($playerLimit <= 0)
             $playerLimit = 5;
 
-        if ($playerLimit > 128)
-            $playerLimit = 128;
+        if ($playerLimit > 254)
+            $playerLimit = 254;
 
         return $playerLimit;
     }


### PR DESCRIPTION
[Both](https://github.com/rcelyte/BeatUpRcelyte/commit/d9b1597b8668b8fd25dafad334232bcec3fe8520) [modded](https://github.com/BeatTogether/BeatTogether.DedicatedServer/commit/7295823ae04b348721a5e026bbbacd3ea0d80ba3) servers implement extended player IDs (8-bit inbound, 7 outbound), supporting up to 254 player lobbies (or 250 on BeatTogether, as they appear to be reserving the last 4 IDs for "future features").